### PR TITLE
ui.sh: merge Chromium feature flags so all of them apply

### DIFF
--- a/services/ui.sh
+++ b/services/ui.sh
@@ -279,10 +279,16 @@ xinit /bin/bash -c '
       DBUS_WRAP=(dbus-run-session --)
     fi
 
+    # Chromium honours only the LAST --enable-features and the LAST
+    # --disable-features on the command line; earlier occurrences are
+    # silently dropped. These had grown to four separate
+    # --disable-features flags, so only InfiniteSessionRestore was
+    # actually being applied - TranslateUI, IsolateOrigins,
+    # site-per-process and MediaRouter were not, despite appearing in
+    # the command. Keep one comma-joined flag of each kind.
     "${DBUS_WRAP[@]}" "$CHROMIUM_BIN" \
       --user-data-dir="$CHROMIUM_DATA_DIR" \
       --force-dark-mode \
-      --enable-features=WebUIDarkMode \
       --disable-application-cache \
       --disable-cache \
       --disable-offline-load-stale-cache \
@@ -299,20 +305,15 @@ xinit /bin/bash -c '
       --disable-infobars \
       --disable-translate \
       --disable-session-crashed-bubble \
-      --disable-features=TranslateUI \
       --no-first-run \
       --disable-default-apps \
       --disable-component-extensions-with-background-pages \
       --disable-background-networking \
       --disable-sync \
       --ignore-certificate-errors \
-      --disable-features=IsolateOrigins,site-per-process \
       --disable-extensions \
       --disable-dev-shm-usage \
-      --enable-features=OverlayScrollbar \
       --overscroll-history-navigation=0 \
-      --disable-features=MediaRouter \
-      --disable-features=InfiniteSessionRestore \
       --disable-pinch \
       --disable-gesture-typing \
       --disable-hang-monitor \
@@ -320,6 +321,8 @@ xinit /bin/bash -c '
       --hide-crash-restore-bubble \
       --disable-breakpad \
       --disable-crash-reporter \
+      --enable-features=WebUIDarkMode,OverlayScrollbar \
+      --disable-features=TranslateUI,IsolateOrigins,site-per-process,MediaRouter,InfiniteSessionRestore \
       --remote-debugging-port=9222
 
     EXIT_CODE=$?

--- a/tests/unit/python/test_ui_chromium_flags.py
+++ b/tests/unit/python/test_ui_chromium_flags.py
@@ -1,0 +1,45 @@
+"""Chromium is launched with exactly one feature flag of each kind.
+
+Chromium honours only the *last* --enable-features and the *last*
+--disable-features on a command line; earlier occurrences are silently
+dropped. services/ui.sh had accumulated four --disable-features flags, so
+only InfiniteSessionRestore was really being disabled — TranslateUI,
+IsolateOrigins/site-per-process and MediaRouter were not, despite
+appearing in the command.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+UI_SH = Path(__file__).resolve().parents[3] / "services" / "ui.sh"
+
+
+def _flags(kind: str) -> list[str]:
+    """Every --<kind>-features=... actually passed (comments excluded)."""
+    src = "\n".join(line for line in UI_SH.read_text().splitlines()
+                    if not line.strip().startswith("#"))
+    return re.findall(rf"--{kind}-features=(\S+)", src)
+
+
+def test_one_enable_features_flag():
+    assert len(_flags("enable")) == 1, (
+        "only the last --enable-features counts — merge them, comma-joined")
+
+
+def test_one_disable_features_flag():
+    assert len(_flags("disable")) == 1, (
+        "only the last --disable-features counts — merge them, comma-joined")
+
+
+def test_previously_dropped_features_are_still_requested():
+    """The three that were silently inert before the merge."""
+    disabled = _flags("disable")[0].split(",")
+    for feature in ("TranslateUI", "IsolateOrigins", "site-per-process",
+                    "MediaRouter", "InfiniteSessionRestore"):
+        assert feature in disabled, f"{feature} lost while merging"
+
+
+def test_enable_features_kept_both():
+    enabled = _flags("enable")[0].split(",")
+    assert "WebUIDarkMode" in enabled and "OverlayScrollbar" in enabled


### PR DESCRIPTION
Chromium honours only the last --enable-features and the last --disable-features; earlier occurrences are silently dropped. Four separate --disable-features flags had accumulated, so only InfiniteSessionRestore was actually applied — TranslateUI, IsolateOrigins, site-per-process and MediaRouter were not, despite appearing in the command.