### PR TITLE
camera overlay: use configured titles, show_camera params are optional

### DIFF
--- a/config/homeassistant/example-automation.yaml
+++ b/config/homeassistant/example-automation.yaml
@@ -353,7 +353,14 @@
 #   {"command": "show_page", "params": {"page": "music"}}
 #   {"command": "next_screen"}
 #   {"command": "prev_screen"}
-#   {"command": "show_camera", "params": {"title": "Doorbell", "camera_entity": "camera.doorbell"}}
+#   {"command": "show_camera"}
+#     Shows the cameras from config.json ("cameras"). All params are optional;
+#     to override, name up to 2 cameras (extras are ignored):
+#     {"command": "show_camera", "params": {"cameras": [
+#         {"title": "Front door", "entity": "camera.front_door"},
+#         {"title": "Gate", "entity": "camera.gate"}]}}
+#     A single camera fills the overlay. The older one-camera form still works:
+#     {"command": "show_camera", "params": {"title": "Doorbell", "camera_entity": "camera.doorbell"}}
 #   {"command": "dismiss_camera"}
 #   {"command": "status"}
 #   {"command": "restart", "params": {"target": "all"}}

--- a/services/input.py
+++ b/services/input.py
@@ -1477,6 +1477,55 @@ async def _forward_to_router(event_type: str, data: dict):
         logger.warning('Router broadcast %s failed: %s', event_type, e)
 
 
+MAX_OVERLAY_CAMERAS = 2
+
+
+def normalize_show_camera_cameras(params: dict) -> list:
+    """Normalize show_camera params into a [{'title','entity'}] list.
+
+    Two accepted forms — the array, which mirrors the "cameras" shape in
+    config.json:
+
+        {"cameras": [{"title": "Front door", "entity": "<entity id>"}, ...]}
+
+    and the older singular pair, kept so existing HA automations keep
+    working:
+
+        {"title": "Doorbell", "camera_entity": "<entity id>"}
+
+    An empty result means "use the cameras from config.json" — every
+    parameter is optional. Entries without an entity are dropped and the
+    list is capped at MAX_OVERLAY_CAMERAS (the overlay has two slots).
+    """
+    raw = params.get('cameras')
+    if isinstance(raw, list):
+        cameras = []
+        for item in raw:
+            if not isinstance(item, dict):
+                continue
+            entity = str(item.get('entity') or '').strip()
+            if not entity:
+                continue
+            cameras.append({
+                'entity': entity,
+                'title': str(item.get('title') or '').strip(),
+            })
+            if len(cameras) == MAX_OVERLAY_CAMERAS:
+                break
+        if len(raw) > len(cameras):
+            logger.warning(
+                'show_camera: %d camera(s) given, using %d (max %d, entries '
+                'without an entity are skipped)',
+                len(raw), len(cameras), MAX_OVERLAY_CAMERAS)
+        return cameras
+
+    entity = str(params.get('camera_entity') or '').strip()
+    if entity:
+        return [{'entity': entity,
+                 'title': str(params.get('title') or '').strip()}]
+    return []
+
+
 async def process_command(data: dict) -> dict:
     """Process an incoming command (from HTTP webhook or MQTT).
 
@@ -1557,27 +1606,21 @@ async def process_command(data: dict) -> dict:
         return {'status': 'ok', 'action': 'prev_screen'}
 
     elif command == 'show_camera':
-        title = params.get('title', 'Camera')
-        camera_entity = params.get('camera_entity', '')
-        camera_id = params.get('camera_id', 'camera')
-        actions = params.get('actions', {})
+        cameras = normalize_show_camera_cameras(params)
 
-        if not camera_entity:
-            # The automation has to say which camera; the device has no
-            # opinion about what a home's cameras are called.
-            logger.warning('show_camera without camera_entity — ignoring')
-            return {'status': 'error', 'message': 'camera_entity is required'}
-
-        logger.info('Showing camera overlay: %s (%s)', title, camera_entity)
+        if cameras:
+            logger.info('Showing camera overlay: %s',
+                        ', '.join(c['entity'] for c in cameras))
+        else:
+            # No cameras named — the overlay falls back to config.json.
+            logger.info('Showing camera overlay: cameras from config')
         set_backlight(True)
-        await _forward_to_router('camera_overlay', {
-            'action': 'show',
-            'title': title,
-            'camera_entity': camera_entity,
-            'camera_id': camera_id,
-            'actions': actions
-        })
-        return {'status': 'ok', 'command': 'show_camera', 'title': title}
+        payload = {'action': 'show', 'actions': params.get('actions', {})}
+        if cameras:
+            payload['cameras'] = cameras
+        await _forward_to_router('camera_overlay', payload)
+        return {'status': 'ok', 'command': 'show_camera',
+                'cameras': len(cameras)}
 
     elif command == 'dismiss_camera':
         logger.info('Dismissing camera overlay')

--- a/tests/unit/python/test_camera_defaults.py
+++ b/tests/unit/python/test_camera_defaults.py
@@ -58,10 +58,23 @@ def test_config_json_can_supply_cameras():
     assert "config.cameras" in src and "AppConfig.cameras = config.cameras" in src
 
 
-def test_camera_endpoints_require_an_entity():
+def test_camera_proxy_endpoints_require_an_entity():
     src = (REPO_ROOT / "services" / "input.py").read_text()
     assert src.count('missing "entity" parameter') == 2, "stream and snapshot both need the guard"
-    assert "show_camera without camera_entity" in src
+
+
+def test_show_camera_params_are_optional():
+    """The command itself is the trigger — every parameter is optional.
+
+    show_camera used to reject a message without camera_entity while the
+    overlay ignored the entity it *did* send (it only ever read a "cameras"
+    array), so HA could not actually pick the cameras. Now: no params means
+    fall back to config.json, params override it.
+    """
+    src = (REPO_ROOT / "services" / "input.py").read_text()
+    assert "show_camera without camera_entity" not in src, (
+        "show_camera must not require camera_entity")
+    assert "def normalize_show_camera_cameras" in src
 
 
 def test_demo_config_has_cameras_so_the_emulator_still_shows_them():

--- a/tests/unit/python/test_show_camera_params.py
+++ b/tests/unit/python/test_show_camera_params.py
@@ -1,0 +1,157 @@
+"""Tests for show_camera parameter handling in beo-input.
+
+The camera overlay has two feed slots. Home Assistant may name the cameras
+in the show_camera command, or send no parameters at all and let the
+device use the "cameras" array from config.json.
+
+Historically the handler required a single ``camera_entity`` and forwarded
+it as ``camera_entity``/``title``, but the overlay only ever read a
+``cameras`` array — so the entity HA sent was silently dropped and config
+was always used. These tests pin the normalizer that fixed that.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "services"))
+
+# `hid` is a native USB-HID binding that only exists on the device; stub it so
+# input.py imports on a dev machine and in CI.
+sys.modules.setdefault("hid", type(sys)("hid"))
+
+import input as beo_input  # noqa: E402  (services/input.py)
+
+normalize = beo_input.normalize_show_camera_cameras
+
+
+# ── Empty result means "fall back to config.json" ────────────────────────────
+
+def test_no_params_falls_back_to_config():
+    assert normalize({}) == []
+
+
+def test_empty_camera_array_falls_back_to_config():
+    assert normalize({"cameras": []}) == []
+
+
+def test_actions_only_falls_back_to_config():
+    """A doorbell automation may only relabel the buttons."""
+    assert normalize({"actions": {"left": "Open door"}}) == []
+
+
+def test_entry_without_entity_is_dropped():
+    assert normalize({"cameras": [{"title": "Front door"}]}) == []
+
+
+# ── The cameras array form ───────────────────────────────────────────────────
+
+def test_camera_array_is_used_in_order():
+    assert normalize({"cameras": [
+        {"title": "Front door", "entity": "camera.front"},
+        {"title": "Gate", "entity": "camera.gate"},
+    ]}) == [
+        {"entity": "camera.front", "title": "Front door"},
+        {"entity": "camera.gate", "title": "Gate"},
+    ]
+
+
+def test_camera_array_capped_at_two():
+    result = normalize({"cameras": [
+        {"title": "One", "entity": "camera.one"},
+        {"title": "Two", "entity": "camera.two"},
+        {"title": "Three", "entity": "camera.three"},
+    ]})
+    assert [c["entity"] for c in result] == ["camera.one", "camera.two"]
+
+
+def test_missing_title_is_allowed():
+    """The overlay falls back to a generic label; the entity is what matters."""
+    assert normalize({"cameras": [{"entity": "camera.front"}]}) == [
+        {"entity": "camera.front", "title": ""}]
+
+
+def test_whitespace_is_trimmed():
+    assert normalize({"cameras": [
+        {"title": " Front door ", "entity": " camera.front "}]}) == [
+        {"entity": "camera.front", "title": "Front door"}]
+
+
+def test_junk_entries_are_skipped_not_fatal():
+    assert normalize({"cameras": [
+        "not a dict", None, {"entity": "camera.front", "title": "Front"}]}) == [
+        {"entity": "camera.front", "title": "Front"}]
+
+
+# ── The legacy singular form (documented in example-automation.yaml) ─────────
+
+def test_legacy_singular_pair_still_works():
+    assert normalize({"title": "Doorbell",
+                      "camera_entity": "camera.doorbell"}) == [
+        {"entity": "camera.doorbell", "title": "Doorbell"}]
+
+
+def test_legacy_entity_without_title():
+    assert normalize({"camera_entity": "camera.doorbell"}) == [
+        {"entity": "camera.doorbell", "title": ""}]
+
+
+def test_camera_array_wins_over_legacy_fields():
+    result = normalize({
+        "title": "Doorbell",
+        "camera_entity": "camera.doorbell",
+        "cameras": [{"title": "Gate", "entity": "camera.gate"}],
+    })
+    assert result == [{"entity": "camera.gate", "title": "Gate"}]
+
+
+# ── End-to-end wiring ────────────────────────────────────────────────────────
+#
+# The original bug was not in any single function: the handler forwarded
+# {'camera_entity': ...} while the overlay only read data['cameras'], so the
+# entity vanished between the two. These pin the payload contract itself.
+
+def _forwarded(params):
+    """Run the show_camera command and return the broadcast payload."""
+    forward = AsyncMock()
+    with patch.object(beo_input, "_forward_to_router", forward), \
+            patch.object(beo_input, "set_backlight"):
+        result = asyncio.run(beo_input.process_command(
+            {"command": "show_camera", "params": params}))
+    forward.assert_awaited_once()
+    event_type, data = forward.await_args.args
+    assert event_type == "camera_overlay"
+    assert data["action"] == "show"
+    assert result["status"] == "ok"
+    return data
+
+
+def test_command_forwards_cameras_the_overlay_can_read():
+    data = _forwarded({"cameras": [
+        {"title": "Front door", "entity": "camera.front"},
+        {"title": "Gate", "entity": "camera.gate"},
+    ]})
+    # The overlay reads data['cameras'] — each entry needs entity + title.
+    assert data["cameras"] == [
+        {"entity": "camera.front", "title": "Front door"},
+        {"entity": "camera.gate", "title": "Gate"},
+    ]
+
+
+def test_legacy_command_forwards_as_a_cameras_list():
+    data = _forwarded({"title": "Doorbell", "camera_entity": "camera.doorbell"})
+    assert data["cameras"] == [
+        {"entity": "camera.doorbell", "title": "Doorbell"}]
+
+
+def test_bare_command_omits_cameras_so_the_overlay_uses_config():
+    data = _forwarded({})
+    assert "cameras" not in data
+
+
+def test_actions_still_ride_along():
+    data = _forwarded({"actions": {"left": "Open door"}})
+    assert data["actions"] == {"left": "Open door"}

--- a/web/js/camera-overlay.js
+++ b/web/js/camera-overlay.js
@@ -9,6 +9,7 @@ const CameraOverlayManager = {
     currentData: null,
     currentCameraIndex: 0,
     cameras: [],
+    maxCameras: 2,  // feed slots in the overlay markup
 
     // Configuration
     config: {
@@ -49,16 +50,16 @@ const CameraOverlayManager = {
                 </div>
                 <div class="camera-feeds-dual">
                     <div class="camera-feed-wrapper">
-                        <div class="camera-feed-label">Front door</div>
+                        <div class="camera-feed-label"></div>
                         <div class="camera-feed-container" data-camera="0">
-                            <img class="camera-feed" alt="Front door" />
+                            <img class="camera-feed" alt="" />
                             <div class="camera-loading">Loading...</div>
                         </div>
                     </div>
                     <div class="camera-feed-wrapper">
-                        <div class="camera-feed-label">Gate</div>
+                        <div class="camera-feed-label"></div>
                         <div class="camera-feed-container" data-camera="1">
-                            <img class="camera-feed" alt="Gate" />
+                            <img class="camera-feed" alt="" />
                             <div class="camera-loading">Loading...</div>
                         </div>
                     </div>
@@ -97,8 +98,11 @@ const CameraOverlayManager = {
 
         this.currentData = data;
 
-        // Cameras from the caller, else from config.
-        this.cameras = data.cameras || this.defaultCameras;
+        // Cameras named in the show_camera command win outright; otherwise
+        // fall back to config. Both are capped at the number of slots.
+        const provided = this.normalizeCameras(data.cameras);
+        this.cameras = provided.length ? provided
+                                       : this.normalizeCameras(this.defaultCameras);
         if (!this.cameras.length) {
             // Nothing configured: an empty overlay, or one wired to guessed
             // entity ids, is worse than no overlay.
@@ -106,6 +110,8 @@ const CameraOverlayManager = {
             this.isActive = false;
             return;
         }
+
+        this.applyCameraLayout();
 
         this.isActive = true;
 
@@ -133,6 +139,39 @@ const CameraOverlayManager = {
         if (window.uiStore && window.uiStore.logWebsocketMessage) {
             window.uiStore.logWebsocketMessage(`Camera overlay: ${this.cameras.map(c => c.title).join(', ')}`);
         }
+    },
+
+    // Keep only usable entries and never more than there are slots. Accepts
+    // the config.json shape ({id, title, entity}) and the show_camera
+    // command's ({title, entity}) — they're the same two fields.
+    normalizeCameras(list) {
+        if (!Array.isArray(list)) return [];
+        return list
+            .filter(cam => cam && typeof cam.entity === 'string' && cam.entity.trim())
+            .slice(0, this.maxCameras)
+            .map(cam => ({ ...cam, entity: cam.entity.trim() }));
+    },
+
+    // Labels come from the camera titles; unused slots are hidden so a
+    // single camera gets the full width instead of a dead "Loading..." box.
+    applyCameraLayout() {
+        const feeds = this.overlayElement.querySelector('.camera-feeds-dual');
+        if (feeds) feeds.classList.toggle('single', this.cameras.length === 1);
+
+        this.overlayElement.querySelectorAll('.camera-feed-wrapper')
+            .forEach((wrapper, index) => {
+                const cam = this.cameras[index];
+                if (!cam) {
+                    wrapper.style.display = 'none';
+                    return;
+                }
+                wrapper.style.display = '';
+                const title = cam.title || `Camera ${index + 1}`;
+                const label = wrapper.querySelector('.camera-feed-label');
+                if (label) label.textContent = title;
+                const img = wrapper.querySelector('.camera-feed');
+                if (img) img.alt = title;
+            });
     },
 
     loadAllCameras() {

--- a/web/styles.css
+++ b/web/styles.css
@@ -448,6 +448,15 @@ html, body {
   overflow: hidden;
 }
 
+/* One camera: take the width both slots would have used, keeping the 4:3
+   frame and leaving room for the header and button hints. */
+.camera-feeds-dual.single .camera-feed-container {
+  width: min(904px, 92vw);
+  height: auto;
+  aspect-ratio: 4 / 3;
+  max-height: 62vh;
+}
+
 .camera-feed {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
The overlay's two feed labels were hardcoded to "Front door" and "Gate", ignoring the title set in config.json.

show_camera also rejected any call without camera_entity, yet forwarded the entity as camera_entity while the overlay only ever read a cameras array — so config always won. The command now works with no parameters at all (falling back to config.json), accepts a cameras array of up to two entries to override it, and still honours the singular title/camera_entity form. A single camera fills the overlay instead of leaving a dead "Loading..." tile.