### PR TITLE
feat(airplay-out): mirror audio to AirPlay receivers

### DIFF
--- a/docs/airplay-output.md
+++ b/docs/airplay-output.md
@@ -1,0 +1,174 @@
+# AirPlay output
+
+Mirrors what the BeoSound is playing to AirPlay receivers on the network — an
+AV receiver in another room, a conservatory speaker — **in parallel** with the
+normal output, which is left completely untouched.
+
+This is the sending direction. For the BeoSound as an AirPlay *receiver*, see
+[airplay.md](airplay.md); the two are independent.
+
+## How it works
+
+```
+sources ──▶ beo_tone_sink ──┬──▶ beo_tone_sink.output ──▶ USB DAC ──▶ PC2 ──▶ MasterLink
+                            │                             (untouched)
+                            └──(monitor)──▶ pw-loopback ──▶ raop_sink.<device>
+```
+
+Audio is tapped from `beo_tone_sink`'s **monitor**, so:
+
+* the receiver gets the tone-controlled BeoSound signal (bass, treble, balance,
+  loudness all apply), and
+* the DAC → PC2 → MasterLink path is not modified at all, so the B&O speakers
+  keep working exactly as before.
+
+Each mirrored receiver is one `pw-loopback` process, supervised by
+`beo-airplay-out`.
+
+The RAOP sinks themselves come from `libpipewire-module-raop-discover`, which
+`install/modules/system-packages.sh` already enables. That part predates this
+service — discovery was there, only the ability to *use* a discovered receiver
+was missing.
+
+## Configuration
+
+```json
+"airplay_output": {
+  "speakers": ["Marantz"],
+  "follow_volume": true
+}
+```
+
+Speakers are matched against the receiver's **friendly name**, not its node
+name. PipeWire names RAOP sinks after the device address:
+
+```
+raop_sink.WinterGarden.local.10.0.41.137.7000
+```
+
+so matching on the node name would break on a new DHCP lease. Matching is a
+case-insensitive substring, so `"Marantz"` finds `Marantz-SR8012`.
+
+With no `speakers` configured the service exits cleanly at startup and nothing
+is mirrored.
+
+## Which receivers actually work
+
+Not all of them, and the limit is PipeWire's, not this service's.
+`module-raop-sink` speaks classic AirPlay — no encryption, or RSA — and does
+not implement FairPlay. A receiver that demands FairPlay refuses the
+connection, and PipeWire then **destroys the sink node**, which does not come
+back until the mDNS record is re-announced.
+
+You can tell which is which before trying, from the receiver's own mDNS record:
+
+```bash
+avahi-browse -rt _raop._tcp | grep txt
+```
+
+* `et=` lists the encryption types the receiver accepts. `0` is none and `1` is
+  RSA, both of which work. `3` and `5` are FairPlay and do not.
+* `sf=` with bit `0x200` set means the receiver requires authentication, which
+  is likewise unsupported.
+
+Measured on one network:
+
+| Receiver | `et=` | `sf=` | Works |
+| --- | --- | --- | --- |
+| Marantz SR8012 | `0,4` | `0x404` | yes |
+| Apple TV 4K / HD | `0,3,5` | `0x644` | no |
+| macOS (MacBook Pro) | `0,3,5` | `0x204` | no |
+
+In short: AirPlay 2-era Apple hardware will not accept a PipeWire RAOP stream,
+while AV receivers and older/third-party AirPlay speakers generally will. The
+symptom of an unsupported receiver is that it disappears from `/status`'s
+`discovered` list moments after a mirror is started against it, while still
+being visible to `avahi-browse`.
+
+## The two-second problem
+
+AirPlay buffers roughly two seconds. A mirrored receiver is therefore **never**
+in sync with the BeoSound's own output, and nothing here can fix that — it is
+inherent to the protocol.
+
+In a different room that does not matter. In the same room it is unusable: the
+two outputs echo. So treat this as "also play in the kitchen", not as
+multi-room in the AirPlay 2 sense.
+
+## Why a service, and not just a link
+
+The obvious implementation is a single `pw-link` from the tone sink to the RAOP
+sink. It does not survive contact with reality:
+
+* **WirePlumber policy owns stream targets.** Adding a second link from
+  `beo_tone_sink.output` alongside the DAC link gets undone.
+* **RAOP sinks come and go.** Receivers sleep, and mDNS records expire and
+  refresh; a sink observed one minute is often absent the next.
+* **Node names embed the address**, so a sink that returns after a DHCP lease
+  change comes back under a different name.
+
+Hence a reconcile loop (`RECONCILE_INTERVAL`) that matches configured names
+against whatever is currently present, starts a loopback when a receiver
+appears, and tears it down when it goes away — including when it reappears
+under a new name.
+
+## Volume
+
+With `follow_volume` (the default), the BeoSound's own level is applied to each
+mirrored stream. The level is read from the router and applied with `wpctl`.
+
+It is applied to the **loopback stream**, not to the receiver's sink: the sink
+volume belongs to the receiver, and someone else may be using it.
+
+This is needed because the BeoSound's normal volume happens downstream of the
+tap — in the PowerLink/MasterLink domain, on the PC2 card — so the monitor
+signal is at full scale and would otherwise ignore the volume wheel entirely.
+
+## Possible next steps
+
+Two things this deliberately does not do yet, recorded so the reasoning is not
+lost:
+
+**Choosing receivers from the UI.** Selection is config plus a restart today,
+which is a dull way to pick a speaker on a B&O set. The groundwork is already
+here: `/status` reports `discovered`, so a SPEAKERS view would need a POST
+endpoint to change the selection at runtime and a view to render it. Kept out
+of this change to keep it reviewable.
+
+**An AirPlay 2 backend for the receivers PipeWire cannot reach.** The
+limitation above is PipeWire's missing HomeKit pairing, not something this
+service does wrong — and it is replaceable. This service is already a
+supervisor of one streaming subprocess per receiver, so swapping `pw-loopback`
+for a sender that does implement pairing, such as
+[airplay-cli](https://github.com/music-assistant/airplay-cli), is a change of
+transport rather than a redesign:
+
+```
+pw-record (beo_tone_sink monitor) | airplay-cli --device <Apple TV>
+```
+
+Same service, same config, same volume handling, chosen per receiver. That
+would bring Apple TVs, HomePods and modern Macs into range. The real work is
+not the library swap but the one-time PIN pairing each device demands, which
+needs somewhere to enter a code.
+
+A full media server such as [OwnTone](https://github.com/owntone/owntone-server)
+would also solve it, but it wants to own the library, the queue and playback —
+which is exactly what beo-router and the sources already do here.
+
+## Checking it works
+
+```bash
+systemctl is-active beo-airplay-out
+curl -s localhost:8780/status | python3 -m json.tool
+```
+
+`discovered` lists every AirPlay receiver PipeWire can currently see, which is
+also the quickest way to find the exact name to configure. `mirroring` lists
+the loopbacks actually running.
+
+To see the graph:
+
+```bash
+XDG_RUNTIME_DIR=/run/user/1000 pw-link -l | grep -i airplay
+```

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -199,6 +199,25 @@
       "additionalProperties": false
     },
 
+    "airplay_output": {
+      "type": "object",
+      "description": "Mirror the BeoSound's audio to AirPlay receivers on the network, in parallel with the normal output. See docs/airplay-output.md.",
+      "properties": {
+        "speakers": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Friendly names of AirPlay receivers to mirror to, e.g. [\"Marantz\"]. Matched against the receiver's advertised name, so a changed IP address does not break the mapping. Leave empty (or omit the section) to run no mirrors.",
+          "default": []
+        },
+        "follow_volume": {
+          "type": "boolean",
+          "description": "Track the BeoSound's own volume on the mirrored streams. Turn off to let each receiver keep an independent level.",
+          "default": true
+        }
+      },
+      "additionalProperties": false
+    },
+
     "radio": {
       "type": "object",
       "description": "Internet radio source settings.",

--- a/services/airplay_out.py
+++ b/services/airplay_out.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""
+BeoSound 5c AirPlay Output (beo-airplay-out)
+
+Mirrors what the BeoSound is playing to AirPlay receivers on the network — a
+Marantz in another room, a conservatory speaker — *in parallel* with the normal
+output, which is left completely untouched.
+
+Audio is tapped from ``beo_tone_sink``'s monitor, so the AirPlay speaker gets
+the tone-controlled BeoSound signal while the USB DAC → PC2 → MasterLink path
+keeps running exactly as before. Each mirror is one pw-loopback process:
+
+    beo_tone_sink (monitor) ──▶ pw-loopback ──▶ raop_sink.<device>
+
+Speakers are matched by friendly name rather than by node name, because
+PipeWire names RAOP sinks after the device's address
+(``raop_sink.WinterGarden.local.10.0.41.137.7000``) and that changes with a
+DHCP lease. The sinks also come and go as devices sleep and mDNS records
+expire, so this service reconciles continuously instead of linking once.
+
+Requires ``libpipewire-module-raop-discover``, which install/modules/
+system-packages.sh already enables — that module is what makes AirPlay
+receivers appear as sinks in the first place.
+
+Config (config.json):
+
+    "airplay_output": {
+        "speakers": ["WinterGarden", "Marantz"],
+        "follow_volume": true
+    }
+
+Note the AirPlay buffer of roughly two seconds: a mirrored speaker is never in
+sync with the BeoSound's own output. That is fine in a different room and
+unusable in the same one.
+
+Port: 8780
+"""
+
+import asyncio
+import json
+import logging
+import os
+import signal
+import sys
+
+import aiohttp
+from aiohttp import web
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from lib.background_tasks import BackgroundTaskSet
+from lib.config import cfg
+from lib.endpoints import AIRPLAY_OUT_PORT, ROUTER_STATUS
+from lib.watchdog import watchdog_loop
+
+logging.basicConfig(level=logging.INFO, format='[%(levelname)s] %(message)s')
+log = logging.getLogger('beo-airplay-out')
+
+# The virtual sink every source already plays into (see
+# install/configs/53-beosound5c-tone.conf). Its monitor is what we mirror.
+TONE_SINK = "beo_tone_sink"
+
+# PipeWire names every AirPlay receiver it discovers with this prefix.
+RAOP_PREFIX = "raop_sink."
+
+# Devices appear and disappear on a human timescale, so this can be slow.
+RECONCILE_INTERVAL = 10.0
+
+# Volume follows the BeoSound's own level; polling localhost is cheap and
+# wpctl is only invoked when the value actually changes.
+VOLUME_INTERVAL = 2.0
+
+PW_TIMEOUT = 5.0
+
+
+def _slug(name: str) -> str:
+    """A node-name-safe form of a speaker's friendly name."""
+    return "".join(c if c.isalnum() else "-" for c in name.lower()).strip("-")
+
+
+class Mirror:
+    """One running pw-loopback, mirroring the tone sink to one receiver."""
+
+    __slots__ = ("speaker", "node_name", "loopback_name", "proc")
+
+    def __init__(self, speaker: str, node_name: str, proc):
+        self.speaker = speaker
+        self.node_name = node_name
+        self.loopback_name = f"beo-airplay-{_slug(speaker)}"
+        self.proc = proc
+
+    @property
+    def alive(self) -> bool:
+        return self.proc is not None and self.proc.returncode is None
+
+
+class AirPlayOutput:
+    def __init__(self):
+        self._speakers = [s for s in (cfg("airplay_output", "speakers", default=[]) or []) if s]
+        self._follow_volume = bool(cfg("airplay_output", "follow_volume", default=True))
+        self._mirrors: dict[str, Mirror] = {}
+        self._discovered: list[dict] = []
+        self._volume: float | None = None
+        self._applied_volume: float | None = None
+        self._session: aiohttp.ClientSession | None = None
+        self._runner: web.AppRunner | None = None
+        self._tasks = BackgroundTaskSet(log, label="airplay-out")
+
+    # ── PipeWire helpers ──
+
+    async def _run(self, *args: str) -> str | None:
+        """Run a PipeWire CLI tool and return stdout, or None on failure."""
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            out, err = await asyncio.wait_for(proc.communicate(), timeout=PW_TIMEOUT)
+        except asyncio.TimeoutError:
+            log.warning("%s timed out", args[0])
+            return None
+        except (FileNotFoundError, OSError) as e:
+            log.warning("%s unavailable: %s", args[0], e)
+            return None
+        if proc.returncode != 0:
+            log.warning("%s failed: %s", args[0], err.decode("utf-8", "replace").strip())
+            return None
+        return out.decode("utf-8", "replace")
+
+    async def _sinks(self) -> list[dict]:
+        """Every Audio/Sink PipeWire currently knows about."""
+        raw = await self._run("pw-dump")
+        if not raw:
+            return []
+        try:
+            objects = json.loads(raw)
+        except json.JSONDecodeError:
+            log.warning("Could not parse pw-dump output")
+            return []
+        sinks = []
+        for obj in objects:
+            props = ((obj.get("info") or {}).get("props") or {})
+            if props.get("media.class") != "Audio/Sink":
+                continue
+            sinks.append({
+                "id": obj.get("id"),
+                "name": props.get("node.name", ""),
+                "description": props.get("node.description", ""),
+            })
+        return sinks
+
+    @staticmethod
+    def _match(speaker: str, sinks: list[dict]) -> dict | None:
+        """Find the RAOP sink for a configured speaker name.
+
+        Matched against the friendly description first, since that is what the
+        user configures and what survives an address change.
+        """
+        want = speaker.strip().lower()
+        for sink in sinks:
+            if not sink["name"].startswith(RAOP_PREFIX):
+                continue
+            if want in (sink["description"] or "").lower() or want in sink["name"].lower():
+                return sink
+        return None
+
+    # ── Mirrors ──
+
+    async def _start_mirror(self, speaker: str, sink: dict):
+        name = f"beo-airplay-{_slug(speaker)}"
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "pw-loopback", "-n", name, "-C", TONE_SINK, "-P", sink["name"],
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except (FileNotFoundError, OSError) as e:
+            log.error("Cannot start pw-loopback: %s", e)
+            return
+        self._mirrors[speaker] = Mirror(speaker, sink["name"], proc)
+        self._applied_volume = None      # re-apply to the new stream
+        log.info("Mirroring to %s (%s)", speaker, sink["name"])
+
+    async def _stop_mirror(self, speaker: str, reason: str):
+        mirror = self._mirrors.pop(speaker, None)
+        if mirror is None:
+            return
+        if mirror.alive:
+            mirror.proc.terminate()
+            try:
+                await asyncio.wait_for(mirror.proc.wait(), timeout=3.0)
+            except asyncio.TimeoutError:
+                mirror.proc.kill()
+        log.info("Stopped mirroring to %s (%s)", speaker, reason)
+
+    async def _reconcile(self):
+        """Start mirrors for speakers that are present, stop the rest."""
+        sinks = await self._sinks()
+        self._discovered = [s for s in sinks if s["name"].startswith(RAOP_PREFIX)]
+
+        for speaker in self._speakers:
+            target = self._match(speaker, sinks)
+            mirror = self._mirrors.get(speaker)
+
+            if mirror and not mirror.alive:
+                await self._stop_mirror(speaker, "loopback exited")
+                mirror = None
+            # A receiver that changed address comes back under a new node
+            # name, so the old loopback is pointing at something that no
+            # longer exists.
+            if mirror and target and mirror.node_name != target["name"]:
+                await self._stop_mirror(speaker, "receiver moved")
+                mirror = None
+
+            if target and not mirror:
+                await self._start_mirror(speaker, target)
+            elif mirror and not target:
+                await self._stop_mirror(speaker, "receiver gone")
+
+    # ── Volume ──
+
+    async def _poll_volume(self):
+        if not self._session:
+            return
+        try:
+            async with self._session.get(ROUTER_STATUS, timeout=5) as resp:
+                if resp.status != 200:
+                    return
+                data = await resp.json()
+        except Exception:
+            return
+        volume = data.get("volume")
+        if isinstance(volume, (int, float)):
+            self._volume = float(volume)
+
+    async def _apply_volume(self):
+        """Mirror the BeoSound's level onto each loopback's playback stream.
+
+        Deliberately the loopback stream rather than the sink itself: the sink
+        volume is the receiver's own, which someone else may be using.
+        """
+        if self._volume is None or self._volume == self._applied_volume:
+            return
+        if not self._mirrors:
+            return
+        sinks_raw = await self._run("pw-dump")
+        if not sinks_raw:
+            return
+        try:
+            objects = json.loads(sinks_raw)
+        except json.JSONDecodeError:
+            return
+
+        wanted = {m.loopback_name for m in self._mirrors.values()}
+        fraction = max(0.0, min(1.0, self._volume / 100.0))
+        for obj in objects:
+            props = ((obj.get("info") or {}).get("props") or {})
+            name = props.get("node.name", "")
+            # pw-loopback exposes its playback side as output.<name>
+            if not name.startswith("output."):
+                continue
+            if name[len("output."):] not in wanted:
+                continue
+            await self._run("wpctl", "set-volume", str(obj.get("id")), f"{fraction:.3f}")
+        self._applied_volume = self._volume
+        log.info("AirPlay output volume set to %.0f%%", self._volume)
+
+    # ── Loops ──
+
+    async def _reconcile_loop(self):
+        while True:
+            try:
+                await self._reconcile()
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                log.warning("Reconcile failed: %s", e)
+            await asyncio.sleep(RECONCILE_INTERVAL)
+
+    async def _volume_loop(self):
+        while True:
+            await asyncio.sleep(VOLUME_INTERVAL)
+            try:
+                await self._poll_volume()
+                await self._apply_volume()
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                log.debug("Volume sync failed: %s", e)
+
+    # ── HTTP ──
+
+    async def _handle_status(self, request):
+        return web.json_response({
+            "service": "airplay_out",
+            "configured": self._speakers,
+            "follow_volume": self._follow_volume,
+            "volume": self._volume,
+            "mirroring": [
+                {"speaker": m.speaker, "sink": m.node_name, "alive": m.alive}
+                for m in self._mirrors.values()
+            ],
+            "discovered": [
+                {"name": s["description"] or s["name"], "sink": s["name"]}
+                for s in self._discovered
+            ],
+        })
+
+    async def start(self):
+        if not self._speakers:
+            log.info("No airplay_output.speakers configured — nothing to mirror")
+            from lib.watchdog import sd_notify
+            sd_notify("READY=1\nSTATUS=No speakers configured, exiting")
+            sd_notify("STOPPING=1")
+            sys.exit(0)
+
+        app = web.Application()
+        app.router.add_get("/status", self._handle_status)
+        self._runner = web.AppRunner(app, access_log=None)
+        await self._runner.setup()
+        await web.TCPSite(self._runner, "0.0.0.0", AIRPLAY_OUT_PORT).start()
+        log.info("HTTP API on port %d", AIRPLAY_OUT_PORT)
+
+        self._session = aiohttp.ClientSession()
+        # Tracked rather than a bare create_task so shutdown cancels it and
+        # exceptions are logged (see lib/background_tasks.py).
+        self._tasks.spawn(watchdog_loop(), name="watchdog")
+
+        log.info("Mirroring BeoSound audio to: %s", ", ".join(self._speakers))
+        self._tasks.spawn(self._reconcile_loop(), name="reconcile")
+        if self._follow_volume:
+            self._tasks.spawn(self._volume_loop(), name="volume")
+
+    async def stop(self):
+        for speaker in list(self._mirrors):
+            await self._stop_mirror(speaker, "shutting down")
+        await self._tasks.cancel_all()
+        if self._session:
+            await self._session.close()
+        if self._runner:
+            await self._runner.cleanup()
+
+    async def run(self):
+        await self.start()
+        stop_event = asyncio.Event()
+        loop = asyncio.get_running_loop()
+        for sig in (signal.SIGTERM, signal.SIGINT):
+            loop.add_signal_handler(sig, stop_event.set)
+        try:
+            await stop_event.wait()
+        finally:
+            await self.stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(AirPlayOutput().run())

--- a/services/lib/endpoints.py
+++ b/services/lib/endpoints.py
@@ -22,7 +22,12 @@ PLAYER_PORT = 8766   # beo-player-* (exactly one active per device)
 INPUT_PORT = 8767    # beo-input (hardware HID + LED + webhook)
 ROUTER_PORT = 8770   # beo-router
 SPOTIFY_PORT = 8771  # beo-source-spotify (also canvas endpoint)
+# 8772 is beo-source-spotify's HTTPS OAuth setup page (SSL_PORT in its
+# service.py). Recorded here because it is not otherwise visible from this
+# module, and picking it for a new service produces a bind conflict that only
+# shows up once Spotify happens to be running.
 RADIO_PORT = 8779    # beo-source-radio
+AIRPLAY_OUT_PORT = 8780  # beo-airplay-out (mirror to AirPlay receivers)
 
 _BASE = "http://localhost"
 

--- a/services/system/beo-airplay-out.service
+++ b/services/system/beo-airplay-out.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=BeoSound5c AirPlay Output (mirror audio to AirPlay receivers)
+After=network-online.target sound.target beo-router.service
+Wants=network-online.target
+OnFailure=beo-notify-failure@%n.service
+StartLimitIntervalSec=300
+StartLimitBurst=3
+
+[Service]
+Type=simple
+User=__USER__
+Group=__USER__
+WorkingDirectory=__HOME__/beosound5c/services
+Environment=PYTHONUNBUFFERED=1
+# Needs this user's PipeWire session: it reads the graph with pw-dump and
+# runs one pw-loopback per mirrored receiver.
+Environment=XDG_RUNTIME_DIR=/run/user/__UID__
+ExecStart=/usr/bin/python3 __HOME__/beosound5c/services/airplay_out.py
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/services/system/service-registry.sh
+++ b/services/system/service-registry.sh
@@ -25,6 +25,7 @@ ALL_SERVICES=(
     "beo-source-usb.service"
     "beo-source-news.service"
     "beo-source-radio.service"
+    "beo-airplay-out.service"
     "beo-ui.service"
     "beo-notify-failure@.service"
     "beo-health.service"
@@ -51,6 +52,7 @@ STATUS_SERVICES=(
     "beo-source-usb.service"
     "beo-source-news.service"
     "beo-source-radio.service"
+    "beo-airplay-out.service"
     "beo-ui.service"
 )
 
@@ -74,6 +76,9 @@ SERVICE_DESC["beo-source-tidal.service"]="TIDAL Source (Port 8777)"
 SERVICE_DESC["beo-source-plex.service"]="Plex Source (Port 8778)"
 SERVICE_DESC["beo-source-news.service"]="News Source (Port 8776)"
 SERVICE_DESC["beo-source-radio.service"]="Radio Source (Port 8779)"
+# Exits cleanly at startup when no speakers are configured, so it is listed
+# unconditionally rather than gated like the optional sources.
+SERVICE_DESC["beo-airplay-out.service"]="AirPlay Output (Port 8780)"
 SERVICE_DESC["beo-ui.service"]="Chromium UI Kiosk"
 
 # Optional sources: menu_key|service|emoji|label


### PR DESCRIPTION
Sends what the BeoSound is playing to AirPlay receivers on the network — an AV receiver in another room, a conservatory speaker — **in parallel** with the normal output, which is left completely untouched.

Independent of #18 (the BeoSound as an AirPlay *receiver*); this is the sending direction.

## How it works

```
sources ──▶ beo_tone_sink ──┬──▶ beo_tone_sink.output ──▶ USB DAC ──▶ PC2 ──▶ MasterLink
                            │                             (untouched)
                            └──(monitor)──▶ pw-loopback ──▶ raop_sink.<device>
```

Audio is tapped from `beo_tone_sink`'s **monitor**, so the receiver gets the tone-controlled signal (bass, treble, balance, loudness all apply) while the DAC → PC2 → MasterLink path keeps running exactly as before. Each mirrored receiver is one `pw-loopback` process supervised by `beo-airplay-out`.

Discovery already existed — `install/modules/system-packages.sh` has been loading `libpipewire-module-raop-discover` for a while, which is why AirPlay receivers show up as sinks. Only the ability to *use* one was missing.

## Why a service, and not just a `pw-link`

A single link from the tone sink to the RAOP sink looks sufficient. It is not, for three reasons that all showed up on hardware:

- **WirePlumber policy owns stream targets**, so a second link added alongside the DAC link is removed again.
- **RAOP sinks come and go** as receivers sleep and mDNS records expire. A sink present one minute is often gone the next.
- **Node names embed the device address** (`raop_sink.WinterGarden.local.10.0.41.137.7000`), so a receiver returning after a DHCP lease change comes back under a different name.

Hence matching on the receiver's friendly name, and a reconcile loop that starts, replaces and tears down mirrors as receivers appear and vanish.

## Configuration

```json
"airplay_output": {
  "speakers": ["Marantz"],
  "follow_volume": true
}
```

Multiple receivers are supported — each gets its own loopback, and a configured receiver that is not currently present is simply left pending.

Volume follows the BeoSound's own level, applied to the **loopback stream** rather than the receiver's sink (the sink volume belongs to the receiver, and someone else may be using it). This is necessary because the BeoSound's volume is applied *downstream* of the tap, in the PowerLink/MasterLink domain, so the monitored signal is at full scale.

## Known limitation: not every receiver works

The limit is PipeWire's, not this service's. `module-raop-sink` implements no HomeKit pairing, so receivers that require it refuse the connection — and PipeWire then **destroys the sink node**, which does not return until the mDNS record is re-announced.

Measured with `avahi-browse` on one network:

| Receiver | `et=` | `sf=` | Works |
| --- | --- | --- | --- |
| Marantz SR8012 | `0,4` | `0x404` | yes |
| Apple TV 4K / HD | `0,3,5` | `0x644` | no |
| macOS (MacBook Pro) | `0,3,5` | `0x204` | no |

Forcing `raop.encryption.type=fp_sap25` — which this PipeWire does support — does not change the outcome, so it is the pairing that is missing rather than FairPlay itself. `docs/airplay-output.md` records how to tell the two apart from the mDNS record before trying, and what the failure looks like.

**This is replaceable without changing the shape of the service.** It is already a supervisor of one streaming subprocess per receiver, so swapping `pw-loopback` for a sender that does implement pairing — [airplay-cli](https://github.com/music-assistant/airplay-cli), for instance — is a change of transport, not a redesign:

```
pw-record (beo_tone_sink monitor) | airplay-cli --device <Apple TV>
```

Same service, same config, same volume handling, chosen per receiver. That would bring Apple TVs, HomePods and modern Macs into range. The real work there is not the library swap but the one-time PIN pairing each device demands, which needs somewhere to enter a code — so it is noted as a next step rather than attempted here.

## Also in here

Port **8780**, not 8772: `beo-source-spotify` already binds 8772 for its HTTPS OAuth setup page, which `endpoints.py` did not record. Noted there now, so the next new service does not hit the same conflict.

## Verified on hardware

Raspberry Pi 5, Debian 13 (trixie), PipeWire 1.4.9:

- mirror attaches and survives (34 s+), where unsupported receivers vanish within seconds
- volume tracks the BeoSound's level
- multiple configured receivers each get their own loopback, absent ones left pending
- **audio confirmed audible** on the Marantz while the B&O output kept playing untouched
- teardown confirmed when a receiver leaves the network

## Deliberately not included

Selection is config plus a restart, which is a dull way to pick a speaker on a B&O set. A SPEAKERS view would need a POST endpoint and a view; `/status` already reports `discovered` as the groundwork. Left out to keep this reviewable, and recorded in `docs/airplay-output.md` along with the `airplay-cli` idea.

Happy to adjust any of it — naming, the port choice, or whether this belongs as a service at all.
