### PR TITLE
feat(ha): show Home Assistant readings in a HOME view

### DIFF
--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -103,6 +103,26 @@
           "format": "uri",
           "description": "HA webhook endpoint for button/event forwarding (used when transport.mode is 'webhook' or 'both').",
           "default": "http://homeassistant.local:8123/api/webhook/beosound5c"
+        },
+        "panel": {
+          "type": "array",
+          "description": "Entities shown in the HOME view, in this order. Read-only readouts. Requires HA_TOKEN in secrets.env; no Home Assistant configuration changes are needed. See docs/home-assistant.md.",
+          "items": {
+            "oneOf": [
+              { "type": "string", "description": "Entity id; the label comes from the entity's friendly_name." },
+              {
+                "type": "object",
+                "required": ["entity"],
+                "properties": {
+                  "entity": { "type": "string", "description": "Home Assistant entity id.", "examples": ["sensor.outdoor_temperature"] },
+                  "label": { "type": "string", "description": "Override the entity's friendly_name." },
+                  "icon": { "type": "string", "description": "Phosphor icon name, e.g. \"thermometer-simple\". Defaults to one picked from the entity domain." }
+                },
+                "additionalProperties": false
+              }
+            ]
+          },
+          "default": []
         }
       },
       "additionalProperties": false

--- a/docs/home-assistant.md
+++ b/docs/home-assistant.md
@@ -42,6 +42,51 @@ Set `transport.mode` to `"webhook"` and configure a webhook URL in the web UI. T
 
 For bidirectional control, use MQTT or `"both"`.
 
+## Showing Home Assistant readings on the device
+
+The HOME view puts entity states on the arc, scrolled with the wheel like any
+other list. It reads through `beo-input`, which already holds a long-lived
+token, so **no Home Assistant configuration is needed** — in particular none of
+the framing and auth changes described in the next section.
+
+List the entities in `config.json`, in the order you want them:
+
+```json
+"home_assistant": {
+  "url": "http://homeassistant.local:8123",
+  "panel": [
+    "sensor.outdoor_temperature",
+    { "entity": "sensor.battery_level", "label": "Battery", "icon": "battery-charging" },
+    { "entity": "sensor.solar_now", "label": "Solar", "icon": "sun-dim" }
+  ]
+}
+```
+
+A bare string uses the entity's own `friendly_name`. The object form overrides
+the label and the [Phosphor](https://phosphoricons.com) icon; without an icon,
+one is picked from the entity domain.
+
+Add the menu item, pointing at the local page:
+
+```json
+"menu": {
+  "HOME": { "url": "softarc/home.html" }
+}
+```
+
+Values refresh every 15 seconds and the selected row is preserved across a
+refresh. Readings are **read-only**: GO does nothing, because a status panel
+that acted on a button press would be a trap. To *control* Home Assistant from
+the device, use SCENES, which already sends actions over the configured
+transport.
+
+An entity that does not resolve is shown dimmed as `unavailable` rather than
+being dropped, since the likeliest cause is a typo in the config.
+
+Requires `HA_TOKEN` in `/etc/beosound5c/secrets.env` (settable from the device's
+own configuration page). Without it the view says so instead of failing
+silently.
+
 ## HA configuration.yaml
 
 Add the following if you want to embed Home Assistant pages in the BS5c UI (e.g. the Security camera view):

--- a/services/input.py
+++ b/services/input.py
@@ -1834,6 +1834,79 @@ async def handle_people(request):
         response.headers['Access-Control-Allow-Origin'] = '*'
         return response
 
+async def handle_ha_panel(request):
+    """Resolve the entities listed in home_assistant.panel for the HOME view.
+
+    One bulk /api/states call rather than one request per entity: a house
+    typically exposes a few thousand entities, and a handful of sequential
+    round trips across the network costs more than fetching once and
+    filtering here.
+
+    Entities are returned in the order they are configured — the view renders
+    them as listed, not in whatever order Home Assistant answers.
+    """
+    if request.method == 'OPTIONS':
+        return web.Response(headers={
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Methods': 'GET, OPTIONS',
+            'Access-Control-Allow-Headers': 'Content-Type',
+        })
+
+    panel = cfg("home_assistant", "panel", default=[]) or []
+    ha_url = cfg("home_assistant", "url", default="http://homeassistant.local:8123")
+    ha_token = os.getenv('HA_TOKEN', '')
+
+    # Nothing configured, or HA was never set up: answer empty rather than
+    # probing, so the view can say so and the log stays quiet.
+    if not panel or not ha_token:
+        response = web.json_response([])
+        response.headers['Access-Control-Allow-Origin'] = '*'
+        return response
+
+    wanted = {}
+    for item in panel:
+        if isinstance(item, str):
+            wanted.setdefault(item, {})
+        elif isinstance(item, dict) and item.get('entity'):
+            wanted.setdefault(item['entity'], item)
+
+    try:
+        session = await get_http_session()
+        headers = {'Authorization': f'Bearer {ha_token}'}
+        async with session.get(f'{ha_url}/api/states', headers=headers) as resp:
+            if resp.status != 200:
+                response = web.json_response(
+                    {'error': f'Home Assistant returned {resp.status}'},
+                    status=resp.status)
+                response.headers['Access-Control-Allow-Origin'] = '*'
+                return response
+            all_states = await resp.json()
+    except Exception as e:
+        logger.error('HA panel error: %s', e)
+        response = web.json_response({'error': str(e)}, status=502)
+        response.headers['Access-Control-Allow-Origin'] = '*'
+        return response
+
+    by_id = {e.get('entity_id'): e for e in all_states}
+    result = []
+    for entity_id, conf in wanted.items():
+        entity = by_id.get(entity_id)
+        attrs = (entity or {}).get('attributes', {})
+        # A missing entity is reported rather than dropped: a silently short
+        # list hides a typo in the config, which is the likeliest cause.
+        result.append({
+            'entity_id': entity_id,
+            'label': conf.get('label') or attrs.get('friendly_name') or entity_id,
+            'state': entity.get('state', 'unknown') if entity else 'unavailable',
+            'unit': attrs.get('unit_of_measurement', ''),
+            'icon': conf.get('icon', ''),
+            'available': entity is not None,
+        })
+
+    response = web.json_response(result)
+    response.headers['Access-Control-Allow-Origin'] = '*'
+    return response
+
 async def handle_bt_remotes(request):
     """Get paired Bluetooth remotes."""
     # Handle CORS preflight
@@ -2143,6 +2216,8 @@ async def main():
     app.router.add_options('/appletv', handle_appletv)  # CORS preflight
     app.router.add_get('/people', handle_people)
     app.router.add_options('/people', handle_people)  # CORS preflight
+    app.router.add_get('/ha/panel', handle_ha_panel)
+    app.router.add_options('/ha/panel', handle_ha_panel)  # CORS preflight
     app.router.add_get('/health', handle_health)
     app.router.add_get('/info', handle_info)
     app.router.add_get('/led', handle_led)

--- a/web/js/config.js
+++ b/web/js/config.js
@@ -19,6 +19,9 @@ const AppConfig = {
     // Router service
     routerUrl: 'http://localhost:8770',
 
+    // Input service (also proxies the Home Assistant reads: /people, /ha/panel)
+    inputServiceUrl: 'http://localhost:8767',
+
     // CD service
     cdServiceUrl: 'http://localhost:8769',
 

--- a/web/js/demo-backend.js
+++ b/web/js/demo-backend.js
@@ -62,6 +62,7 @@
             { id: 'tidal', title: 'TIDAL', preset: 'tidal', dynamic: true },
             { id: 'plex', title: 'PLEX', preset: 'plex', dynamic: true },
             { id: 'radio', title: 'RADIO', preset: 'radio', dynamic: true },
+            { id: 'home', title: 'HOME', type: 'webpage', url: 'softarc/home.html' },
             { id: 'scenes', title: 'SCENES' },
             { id: 'security', title: 'SECURITY', type: 'webpage',
               url: 'softarc/security.html' },
@@ -216,6 +217,20 @@
                 active_player: 'sonos', output_device: 'BeoLab 5',
                 volume: 32, transport_mode: 'webhook',
             }));
+        }
+
+        // HOME view readouts. Plausible house readings so the view can be
+        // exercised without a Home Assistant to talk to.
+        if (url.includes('/ha/panel')) {
+            return Promise.resolve(jsonResponse([
+                { entity_id: 'sensor.outdoor_temperature', label: 'Outdoor', state: '4.2', unit: '°C', icon: '', available: true },
+                { entity_id: 'sensor.indoor_temperature', label: 'Living room', state: '21.5', unit: '°C', icon: '', available: true },
+                { entity_id: 'sensor.battery_level', label: 'Battery', state: '68', unit: '%', icon: 'battery-charging', available: true },
+                { entity_id: 'sensor.solar_now', label: 'Solar', state: '1.4', unit: 'kW', icon: 'sun-dim', available: true },
+                { entity_id: 'binary_sensor.front_door', label: 'Front door', state: 'closed', unit: '', icon: 'lock', available: true },
+                { entity_id: 'person.demo', label: 'Someone', state: 'home', unit: '', icon: '', available: true },
+                { entity_id: 'sensor.missing_example', label: 'Unconfigured sensor', state: 'unavailable', unit: '', icon: '', available: false },
+            ]));
         }
 
         if (url.includes('/player/status') || url.includes('/player/state')) {

--- a/web/js/view-manager.js
+++ b/web/js/view-manager.js
@@ -139,6 +139,16 @@ class ViewManager {
                 }
                 iframe.style.cssText = 'width:100%;height:100%;border:none;';
                 container.appendChild(iframe);
+
+                // Local pages are BeoSound pages and can answer wheel and
+                // button events, so route input to them. Remote pages (the
+                // Security camera view, say) are passive: registering them
+                // would swallow navigation into an iframe that never
+                // listens, and the shell would stop responding.
+                const isLocal = !/^[a-z]+:\/\//i.test(url);
+                if (isLocal && window.IframeMessenger) {
+                    IframeMessenger.registerIframe(this.currentRoute, iframeId);
+                }
             }
         }
 

--- a/web/softarc/home.html
+++ b/web/softarc/home.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Home - Beosound 5c</title>
+
+    <!-- Favicons -->
+    <link rel="icon" type="image/x-icon" href="../assets/favicons/favicon.ico">
+    <link rel="icon" type="image/png" sizes="16x16" href="../assets/favicons/favicon-16x16.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="../assets/favicons/favicon-32x32.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../assets/favicons/apple-touch-icon.png">
+    <link rel="manifest" href="../assets/favicons/site.webmanifest">
+    <meta name="theme-color" content="#000000">
+
+    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="../assets/phosphor/phosphor.css">
+</head>
+<body>
+    <div id="app">
+        <div class="counter">
+            <div id="counter-path"></div>
+            <span id="current-item">1</span> / <span id="total-items">0</span>
+        </div>
+        <div class="hierarchy-depth-1" id="hierarchy-background"></div>
+        <div class="arc-container" id="arc-container"></div>
+    </div>
+
+    <script src="../js/config.js"></script>
+    <script src="../js/demo-backend.js"></script>
+    <script src="../js/arc-utils.js"></script>
+    <script src="../js/emulator-bridge.js"></script>
+    <script src="script-v2.js"></script>
+    <script>
+        // Home Assistant readouts, rendered as an arc so the wheel scrolls
+        // them like any other list on the device. Values are read-only: the
+        // BeoSound already sends commands to HA through SCENES, and a status
+        // panel that acts on GO would be a trap.
+        const PANEL_URL = getServiceUrl('inputServiceUrl', 8767) + '/ha/panel';
+
+        // How often to re-read. Slow on purpose: these are house readings,
+        // not transport state, and reloadData() keeps the selected row.
+        const REFRESH_MS = 15000;
+
+        // Fallback icon per entity domain. An explicit "icon" in the config
+        // entry always wins.
+        const DOMAIN_ICONS = {
+            sensor: 'gauge',
+            binary_sensor: 'circle',
+            light: 'lightbulb',
+            switch: 'toggle-right',
+            person: 'user',
+            device_tracker: 'user',
+            media_player: 'speaker-high',
+            climate: 'thermometer-simple',
+            lock: 'lock',
+            weather: 'cloud-sun',
+        };
+
+        function iconFor(entityId) {
+            return DOMAIN_ICONS[String(entityId).split('.')[0]] || 'gauge';
+        }
+
+        function mapEntity(entity) {
+            const value = entity.available
+                ? `${entity.state}${entity.unit ? ' ' + entity.unit : ''}`
+                : 'unavailable';
+            return {
+                id: entity.entity_id,
+                // One line per reading: the arc renders a single label, so
+                // the value rides along with it.
+                name: `${entity.label}   ${value}`,
+                icon: entity.icon || iconFor(entity.entity_id),
+                color: entity.available ? '#ffffff' : 'rgba(255,255,255,0.35)',
+                actionable: false,
+            };
+        }
+
+        async function loadPanel() {
+            const resp = await fetch(PANEL_URL);
+            if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+            const data = await resp.json();
+            if (!Array.isArray(data) || data.length === 0) {
+                // An empty answer means either no entities configured or no
+                // Home Assistant token — say so rather than showing a blank
+                // arc that looks like a failure.
+                return [{
+                    entity_id: 'setup',
+                    label: 'Add entities to home_assistant.panel',
+                    state: '',
+                    unit: '',
+                    icon: 'house',
+                    available: true,
+                }];
+            }
+            return data;
+        }
+
+        document.addEventListener('DOMContentLoaded', async () => {
+            try {
+                window.arcListInstance = new ArcList({
+                    rootLoader: loadPanel,
+                    levels: [{ itemMapper: mapEntity, isContainer: () => false }],
+                    storagePrefix: 'home_arclist',
+                    context: 'home',
+                });
+
+                setInterval(() => {
+                    // reloadData() is a no-op below the root level and keeps
+                    // the selected row by id, so a refresh never moves the
+                    // list under the user.
+                    window.arcListInstance.reloadData().catch(() => {});
+                }, REFRESH_MS);
+            } catch (error) {
+                console.error('Home view initialization error:', error);
+                document.body.innerHTML =
+                    '<div style="color:#ff4444;padding:20px;">Error: ' + error.message + '</div>';
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Puts Home Assistant entity states on the arc, scrolled with the wheel like any other list on the device.

Independent of #18 and #19.

## Why not an embedded dashboard

`docs/home-assistant.md` already describes embedding HA pages in an iframe, which is how the Security view works. For *readings* that route costs more than it looks:

- `use_x_frame_options: false` weakens clickjacking protection across the whole HA instance, not just towards the BeoSound.
- A `trusted_networks` provider gives login-free HA access from the device's IP.
- HA dashboards are built for touch and mouse. The BeoSound has a wheel and four buttons. The Security view gets away with it because a camera grid is passive.

`beo-input` already holds a long-lived token and already proxies `/showing` and `/people` from `/api/states`. Reusing that path needs **no Home Assistant configuration at all**, and the view is drawn by the device, so it looks and navigates like the rest of it.

## Configuration

```json
"home_assistant": {
  "url": "http://homeassistant.local:8123",
  "panel": [
    "sensor.outdoor_temperature",
    { "entity": "sensor.battery_level", "label": "Battery", "icon": "battery-charging" }
  ]
},
"menu": {
  "HOME": { "url": "softarc/home.html" }
}
```

A bare string uses the entity's own `friendly_name`; the object form overrides label and Phosphor icon. Requires `HA_TOKEN` in `secrets.env`, which the device's own config page already sets.

## Design notes

**One bulk fetch, not one per entity.** `/ha/panel` resolves the whole list from a single `/api/states` call. A house exposes a few thousand entities, and sequential round trips cost more than fetching once and filtering.

**Missing entities are shown, not dropped.** An unresolved id comes back as `unavailable` and renders dimmed. A silently short list hides the likeliest cause, which is a typo in the config.

**Read-only by design.** GO does nothing. The device already sends actions to HA through SCENES; a status panel that acted on a button press would be a trap.

**Configured order is preserved** — the view renders entities as listed, not in whatever order HA answers.

## One change outside the feature

Webpage menu views now register their iframe with `IframeMessenger`, **but only when the URL is local**. Without it no navigation reaches the page and the wheel does nothing; the existing Security view works only because a remote camera page is passive.

Remote URLs are deliberately left unregistered: routing input into an iframe that never listens would swallow it and leave the shell unresponsive. So the Security view is unaffected.

## Emulator

Per CONTRIBUTING this works with no hardware and no Home Assistant: `demo-backend.js` serves the menu entry and a set of plausible readings, so `cd web && python3 -m http.server 8000` shows HOME and its arc.

## Verified

Raspberry Pi 5, against a live Home Assistant with ~3100 entities:

- configured order preserved, real values and units rendered (`Ute 19 °C`, `Batteri 95.0 %`)
- a deliberately wrong entity id shown as `unavailable` rather than dropped
- `menu/home` confirmed registered with `IframeMessenger`, so wheel input reaches the page
- emulator path checked separately with the demo readings

Happy to adjust naming, the refresh interval, or whether the value belongs in the label rather than a second line.
